### PR TITLE
Fix a bug causing reuse of optReply field

### DIFF
--- a/src/main/java/org/nats/Connection.java
+++ b/src/main/java/org/nats/Connection.java
@@ -751,7 +751,9 @@ public class Connection {
 						receiveBuffer.get(buf, 0, payload_length + 2);
 						on_msg(new String(buf, 0, payload_length)); 
 						pos = 0;
-						status = AWAITING_CONTROL;					
+						status = AWAITING_CONTROL;
+						subject = null;
+						optReply = null;
 						break;
 					}
 				}


### PR DESCRIPTION
There is a bug were the optReply field was not being reset on each message received. In a scenario where the first message received had a reply field but the second message received did not, the reply field was being 'reused' in the message details sent to the handler (as it was not being overwritten). This bug is being fixed by resetting the class level variables subject and optReply to ensure fields are unique to each message.
